### PR TITLE
.editorconfig を追加

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = false
+insert_final_newline = true


### PR DESCRIPTION
`.editorconfig` は各種エディタで自動的に (または拡張機能を介して) 読み込まれ、インデントスタイル/数・改行文字・ファイル末端の空行追加等が設定される。開発環境を整えやすくなるのでとても便利

参考：https://editorconfig.org/