### PR TITLE
eslint が /public ディレクトリを無視するように設定した

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   extends: 'airbnb',
+  ignorePatterns: ['public'],
   plugins: [
     'react',
     'jsx-a11y',


### PR DESCRIPTION
`yarn lint` コマンドを叩いた時に `/public/bundle.js` も lint 対象になっててエラー・警告数がとんでもない数になってたから、 `.eslintrc.js` で `ignorePatterns` オプションを追記して `/public` ディレクトリを除外した