### PR TITLE
テストを修正した

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,13 @@
+import { Config } from '@jest/types';
+
+const config: Config.InitialOptions = {
+  roots: [
+    '<rootDir>/src',
+  ],
+  transformIgnorePatterns: [],
+  moduleNameMapper: {
+    '^.+\\.scss$': '<rootDir>/node_modules/jest-css-modules',
+  },
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "html-webpack-plugin": "^4.4.1",
     "jest": "^26.4.2",
+    "jest-css-modules": "^2.1.0",
     "postcss": "^8.1.6",
     "postcss-loader": "^4.0.2",
     "react-test-renderer": "17.0.1",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "sass": "^1.26.11",
     "sass-loader": "^10.0.2",
     "style-loader": "^1.2.1",
+    "ts-node": "^9.1.1",
     "typescript": "^4.0.5",
     "webpack": "^4.44.2",
     "webpack-cli": "^3.3.12",

--- a/src/ecosystem/history/historyWindow.test.tsx
+++ b/src/ecosystem/history/historyWindow.test.tsx
@@ -5,7 +5,7 @@ import HistoryWindow from './historyWindow';
 
 describe('HistoryWindow Component', () => {
   test('check HistoryWindow behavior', () => {
-    render(<HistoryWindow isTop={true} />);
+    render(<HistoryWindow isTop />);
     expect(screen.getByText('1.5周年', { exact: false })).toBeInTheDocument;
   });
 });

--- a/src/ecosystem/member/memberWindow.test.tsx
+++ b/src/ecosystem/member/memberWindow.test.tsx
@@ -5,7 +5,7 @@ import MemberWindow from './memberWindow';
 
 describe('MemberWindow Component', () => {
   test('check MemberWindow behavior', () => {
-    render(<MemberWindow isRight={true} />);
-    expect(screen.getByText('メンバー', { exact: false })).toBeInTheDocument;
+    render(<MemberWindow isRight />);
+    expect(screen.getByText('サンバカーニバル', { exact: false })).toBeInTheDocument;
   });
 });

--- a/src/ecosystem/top/topWindow.test.tsx
+++ b/src/ecosystem/top/topWindow.test.tsx
@@ -6,6 +6,6 @@ import TopWindow from './topWindow';
 describe('TopWindow Component', () => {
   test('check TopWindow behavior', () => {
     render(<TopWindow />);
-    expect(screen.getByText('さんばか', { exact: false })).toBeInTheDocument;
+    expect(screen.getByText('さんばか1.5周年', { exact: false })).toBeInTheDocument;
   });
 });

--- a/src/organisms/header.test.tsx
+++ b/src/organisms/header.test.tsx
@@ -6,6 +6,6 @@ import Header from './header';
 describe('Header', () => {
   test('check Header behavior', () => {
     render(<Header />);
-    expect(screen.getByText('さんばか', { exact: false })).toBeInTheDocument;
+    expect(screen.getAllByText('さんばか', { exact: false })).toBeInTheDocument;
   });
 });

--- a/src/pages/home.test.tsx
+++ b/src/pages/home.test.tsx
@@ -6,6 +6,6 @@ import Home from './home';
 describe('Home', () => {
   test('check Home behavior', () => {
     render(<Home />);
-    expect(screen.getByText('Home', { exact: false })).toBeInTheDocument;
+    expect(screen.getByText('おめでとうございます', { exact: false })).toBeInTheDocument;
   });
 });

--- a/src/pages/member.test.tsx
+++ b/src/pages/member.test.tsx
@@ -6,6 +6,6 @@ import Member from './member';
 describe('Member', () => {
   test('check Member behavior', () => {
     render(<Member />);
-    expect(screen.getByText('Member', { exact: false })).toBeInTheDocument;
+    expect(screen.getByText('ユニット', { exact: false })).toBeInTheDocument;
   });
 });

--- a/src/pages/road.test.tsx
+++ b/src/pages/road.test.tsx
@@ -6,6 +6,6 @@ import Road from './road';
 describe('Road', () => {
   test('check Road behavior', () => {
     render(<Road />);
-    expect(screen.getByText('Road', { exact: false })).toBeInTheDocument;
+    expect(screen.getByText('歩んできた道のり', { exact: false })).toBeInTheDocument;
   });
 });

--- a/src/pages/site.test.tsx
+++ b/src/pages/site.test.tsx
@@ -6,6 +6,6 @@ import Site from './site';
 describe('Site', () => {
   test('check Site behavior', () => {
     render(<Site />);
-    expect(screen.getByText('Site', { exact: false })).toBeInTheDocument;
+    expect(screen.getByText('サイト制作者', { exact: false })).toBeInTheDocument;
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2432,6 +2432,11 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -3761,6 +3766,11 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-env@^5.1.3:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.1.tgz#b2c76c1ca7add66dc874d11798466094f551b34d"
@@ -4141,6 +4151,11 @@ diff-sequences@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
   integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -7806,6 +7821,11 @@ make-dir@^3.0.0:
   dependencies:
     semver "^6.0.0"
 
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -10227,7 +10247,7 @@ source-map-resolve@^0.6.0:
     atob "^2.1.2"
     decode-uri-component "^0.2.0"
 
-source-map-support@^0.5.16, source-map-support@^0.5.6, source-map-support@~0.5.12:
+source-map-support@^0.5.16, source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.12:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -10959,6 +10979,18 @@ try-require@^1.0.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/try-require/-/try-require-1.2.1.tgz#34489a2cac0c09c1cc10ed91ba011594d4333be2"
   integrity sha1-NEiaLKwMCcHMEO2RugEVlNQzO+I=
+
+ts-node@^9.1.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
+  integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
+  dependencies:
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
+    yn "3.1.1"
 
 tsconfig-paths@^3.9.0:
   version "3.9.0"
@@ -11798,6 +11830,11 @@ yargs@^15.3.1, yargs@^15.4.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 zip-stream@^2.1.2:
   version "2.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5837,6 +5837,11 @@ har-validator@~5.1.3:
     ajv "^6.12.3"
     har-schema "^2.0.0"
 
+harmony-reflect@^1.4.6:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/harmony-reflect/-/harmony-reflect-1.6.1.tgz#c108d4f2bb451efef7a37861fdbdae72c9bdefa9"
+  integrity sha512-WJTeyp0JzGtHcuMsi7rw2VwtkvLa+JyfEKJCFyfcS0+CDkjQ5lHPu7zEhFZP+PDSRrEgXa5Ah0l1MbgbE41XjA==
+
 has-ansi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
@@ -6162,6 +6167,13 @@ idb@3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/idb/-/idb-3.0.2.tgz#c8e9122d5ddd40f13b60ae665e4862f8b13fa384"
   integrity sha512-+FLa/0sTXqyux0o6C+i2lOR0VoS60LU/jzUo5xjfY6+7sEEgy4Gz1O7yFBXvjd7N0NyIGWIRg8DcQSLEG+VSPw==
+
+identity-obj-proxy@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz#94d2bda96084453ef36fbc5aaec37e0f79f1fc14"
+  integrity sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=
+  dependencies:
+    harmony-reflect "^1.4.6"
 
 ieee754@^1.1.13, ieee754@^1.1.4:
   version "1.2.1"
@@ -6770,6 +6782,13 @@ jest-config@^26.6.3:
     jest-validate "^26.6.2"
     micromatch "^4.0.2"
     pretty-format "^26.6.2"
+
+jest-css-modules@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/jest-css-modules/-/jest-css-modules-2.1.0.tgz#9c25ebe9d0214d8f55861a442268fdd4b01b4781"
+  integrity sha512-my3Scnt6l2tOll/eGwNZeh1KLAFkNzdl4MyZRdpl46GO6/93JcKKdTjNqK6Nokg8A8rT84MFLOpY1pzqKBEqMw==
+  dependencies:
+    identity-obj-proxy "3.0.0"
 
 jest-diff@^26.0.0, jest-diff@^26.6.2:
   version "26.6.2"


### PR DESCRIPTION
- Jest 関連の設定を追加して、 `yarn test` 実行時に正常にテストが実行されるようにした
  - Jest の設定を TypeScript で記述するために `ts-node` を導入した
  - `*.test.tsx` のテスト実行中に、`import styles from 'xxx.scss';` の部分でエラーを起こさないように `jest-css-modules` パッケージをインストールした
  - `/jest.config.ts` を追加した
- すべてのテストが通るように、既存のテストを修正した
  - それぞれ TypeScript に移行した
  - typo していたソースファイル名を修正した (`menber.test.js` → `member.test.tsx`)
